### PR TITLE
fixed some bugs and added new C3D10 tetra 10 nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 poetry.lock
+pybaqus/__pycache__/

--- a/pybaqus/elements.py
+++ b/pybaqus/elements.py
@@ -603,6 +603,30 @@ class QuadraticHexahedron(Element):
         }
 
 
+class QuadraticTetra(Element):
+    """10 node quadratic tetra element."""
+    def __init__(self, n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, num, model, code):
+        super().__init__(num, model, code)
+        self._n_nodes = 10
+        self._nodes = [
+            n1, n2, n3, n4, n5, n6, n7, n8, n9, n10
+        ]
+        self._elem_type = vtk.VTK_QUADRATIC_TETRA
+
+        # Define faces connectivity
+        self._faces = {
+            1: [0, 1, 2, 4, 5, 6],
+            2: [0, 3, 1, 7, 8, 4],
+            3: [1, 3, 2, 8, 9, 5],
+            4: [2, 3, 0, 9, 7, 6],
+        }
+        self._face_shape = {
+            1: vtk.VTK_QUADRATIC_TRIANGLE,
+            2: vtk.VTK_QUADRATIC_TRIANGLE,
+            3: vtk.VTK_QUADRATIC_TRIANGLE,
+            4: vtk.VTK_QUADRATIC_TRIANGLE,
+        }
+
 ELEMENTS = {
     # Distributed coupling
     "IDCOUP3U": DistributedCouplingElement,
@@ -640,6 +664,7 @@ ELEMENTS = {
     # 3D Continuum
     "C3D4": Tetra,
     "C3D4H": Tetra,
+    "C3D10": QuadraticTetra,
     "C3D5": Pyramid,
     "C3D6": Wedge,
     "C3D6H": Wedge,
@@ -690,6 +715,7 @@ N_INT_PNTS = {
     # 3D Continuum
     "C3D4": 1,
     "C3D4H": 1,
+    "C3D10": 4,
     "C3D6": 2,
     "C3D6H": 2,
     "C3D8": 8,

--- a/pybaqus/elements.py
+++ b/pybaqus/elements.py
@@ -322,8 +322,7 @@ class Tetra(Element):
         self._nodes = [n1, n2, n3, n4]
         self._elem_type = vtk.VTK_TETRA
 
-        # Define faces connectivity
-        self._faces = {1: [0, 1, 2], 2: [0, 4, 2], 3: [1, 3, 2], 4: [2, 3, 0]}
+        self._faces = {1: [0, 1, 2], 2: [0, 3, 1], 3: [1, 3, 2], 4: [2, 3, 0]}
         self._face_shape = {
             1: vtk.VTK_TRIANGLE,
             2: vtk.VTK_TRIANGLE,

--- a/pybaqus/elements.py
+++ b/pybaqus/elements.py
@@ -518,7 +518,7 @@ class DistributedCouplingElement(Element):
 
 
 class QuadraticQuad(Element):
-    """4-node rectangular element."""
+    """8-node rectangular element."""
     def __init__(self, n1, n2, n3, n4, n5, n6, n7, n8, num, model, code):
         super().__init__(num, model, code)
         self._n_nodes = 4

--- a/pybaqus/fil_result.py
+++ b/pybaqus/fil_result.py
@@ -632,7 +632,8 @@ class FilParser:
         r_type : str
 
         """
-        tqdm.write(f"Record key {record[1]} ({r_type}) not yet implemented!")
+        #tqdm.write(f"Record key {record[1]} ({r_type}) not yet implemented!")
+        print(f"Record key {record[1]} ({r_type}) not yet implemented!")
 
     def _reference_elems_in_nodes(self):
         """Add a list to each node with the elements using the node."""

--- a/pybaqus/model.py
+++ b/pybaqus/model.py
@@ -706,13 +706,10 @@ class Model:
             kmap = {k: ix for k, ix in zip(nodes, new_node_ids)}
             elements = {k: elements[k] for k in elem_ids}
         else:
-            kmap = None
-            #
-            #can replace here the kmap used for get_node_coords of do it outside knowing kmap 
-            #node_ids = sorted(list(self.nodes.keys()))
-            #new_node_ids = np.arange(1, len(node_ids) + 1, 1)
-            ## Map new indices to old indices
-            #kmap = {ix: k for k, ix in zip(new_node_ids, node_ids)}
+            node_ids = sorted(list(self.nodes.keys()))
+            new_node_ids = np.arange(1, len(node_ids) + 1, 1)
+            # Map new indices to old indices. kmap must be according with get_node_coords
+            kmap = {ix: k for k, ix in zip(new_node_ids, node_ids)}
 
         keys = sorted(list(elements.keys()))
 

--- a/pybaqus/model.py
+++ b/pybaqus/model.py
@@ -618,8 +618,13 @@ class Model:
             # Map new indices to old indices
             kmap = {k: ix for k, ix in zip(keys, old_keys)}
         else:
-            keys = sorted(list(nodes.keys()))
-            kmap = {k: k for k in keys}
+            #keys = sorted(list(nodes.keys()))
+            #kmap = {k: k for k in keys}
+            #the previous assumes that nodes are from 1 to n without jumps!!
+            old_keys = sorted(list(nodes.keys()))
+            keys = np.arange(1, len(old_keys) + 1, 1)
+            # Map new indices to old indices
+            kmap = {k: ix for k, ix in zip(keys, old_keys)}
 
         coords = np.empty((len(keys), 3))
 
@@ -702,6 +707,12 @@ class Model:
             elements = {k: elements[k] for k in elem_ids}
         else:
             kmap = None
+            #
+            #can replace here the kmap used for get_node_coords of do it outside knowing kmap 
+            #node_ids = sorted(list(self.nodes.keys()))
+            #new_node_ids = np.arange(1, len(node_ids) + 1, 1)
+            ## Map new indices to old indices
+            #kmap = {ix: k for k, ix in zip(new_node_ids, node_ids)}
 
         keys = sorted(list(elements.keys()))
 


### PR DESCRIPTION
Please, consider merge my changes in your main branch.

I am using your pybaqus module to implement a .fil Abaqus result importer plugin for our GiD program (www.gidsimulation.com)
I have a first version of the GiD-pybaqus importer working, but with the related changes of my fork.

I attach Job-2-E-mod.fil that show the error related with first node nid==2 instead 1
[Job-2-E-mod_fil.zip](https://github.com/cristobaltapia/pybaqus/files/10961349/Job-2-E-mod_fil.zip)

and tetra_10.fil that has C3D10 tetrahedra quadratic missing implementitaon
[tetra_10_fil.zip](https://github.com/cristobaltapia/pybaqus/files/10961362/tetra_10_fil.zip)

Finally I attach a screenshot of GiD with the example Job-2-E-mod.fil imported
![gid_import](https://user-images.githubusercontent.com/39376606/224818482-8ce6698a-26f8-4265-b3a6-a7f74dc5ea16.png)
