### PR TITLE
change error to warning for unsupported element type

### DIFF
--- a/src/pybaqus/fil_result.py
+++ b/src/pybaqus/fil_result.py
@@ -2,7 +2,7 @@
 Class for the Fil results
 """
 import re
-import warnings
+import logging
 
 import numpy as np
 from tqdm import tqdm
@@ -10,6 +10,8 @@ from tqdm import tqdm
 from .model import Model
 from .nodes import Node2D, Node3D
 from .elements import ELEMENTS, N_INT_PNTS
+
+_log = logging.getLogger(__name__)
 
 
 class FilParser:
@@ -157,7 +159,7 @@ class FilParser:
         if e_type in ELEMENTS.keys():
             ElementClass = ELEMENTS[e_type]
         else:
-            warnings.warn(f"Element type {e_type} not supported yet. Skipping.")
+            _log.warning(f"Element type {e_type} not supported yet. Skipping.")
             return
 
         element = ElementClass(*nodes, num=e_number, model=self.model, code=e_type)

--- a/src/pybaqus/fil_result.py
+++ b/src/pybaqus/fil_result.py
@@ -2,6 +2,7 @@
 Class for the Fil results
 """
 import re
+import warnings
 
 import numpy as np
 from tqdm import tqdm
@@ -153,8 +154,11 @@ class FilParser:
                 self._node_elems[n].append(e_number)
             else:
                 self._node_elems[n] = [e_number]
-
-        ElementClass = ELEMENTS[e_type]
+        if e_type in ELEMENTS.keys():
+            ElementClass = ELEMENTS[e_type]
+        else:
+            warnings.warn(f"Element type {e_type} not supported yet. Skipping.")
+            return
 
         element = ElementClass(*nodes, num=e_number, model=self.model, code=e_type)
         element.n_integ_points = N_INT_PNTS[e_type]


### PR DESCRIPTION
Hello,

thanks for the great work on this Abaqus output reader. This is quite useful. 

However, I was facing some issues when I was trying to access some nodal values of a result that contained unsupported elements. I think it would be useful to change the behavior from giving an error on unsupported elements to giving just a warning. This way the code keeps running and one can still evaluate the rest of the result file, even if it contains unsupported elements. We could even add a message like "please open an issue for your element type".

Also, would it be possible to decrease the required numpy versions? I know that some other libraries like [OpenMDAO](https://openmdao.org/newdocs/versions/latest/main.html) don't support numpy 2.0 yet. 