### PR TITLE
Fix node init

### DIFF
--- a/src/pybaqus/fil_result.py
+++ b/src/pybaqus/fil_result.py
@@ -2,15 +2,17 @@
 Class for the Fil results
 see ABAQUS Analysis User's Manual. FILE OUTPUT FORMAT (ANALYSIS_1.pdf)
 """
-import re
+
 import logging
+import re
 
 import numpy as np
+from numpy.typing import NDArray
 from tqdm import tqdm
 
+from .elements import ELEMENTS, N_INT_PNTS
 from .model import Model
 from .nodes import Node2D, Node3D
-from .elements import ELEMENTS, N_INT_PNTS
 
 _log = logging.getLogger(__name__)
 
@@ -330,7 +332,7 @@ class FilParser:
         self._curr_output_node: int = None
         self._output_request_set: str = None
         self._output_elem_type: str = None
-        self._dof_map: dict = dict()
+        self._dof_map: NDArray = np.array([])
         self._model_dimension: int = None
         self._node_records: list = list()
 
@@ -355,8 +357,13 @@ class FilParser:
         )
 
         # Parse each record
-        for r_i in tqdm(records, disable=(not progress), leave=False, unit="record",
-                        dynamic_ncols=True):
+        for r_i in tqdm(
+            records,
+            disable=(not progress),
+            leave=False,
+            unit="record",
+            dynamic_ncols=True,
+        ):
             m_rec = pattern.findall(r_i)
 
             # Get each variable
@@ -430,13 +437,13 @@ class FilParser:
             self._node_records.append(record)
         else:
             n_number = record[2]
-            dofs = record[3:]
+            coords = record[3:]
             dof_map = self._dof_map
 
             if self._model_dimension == 2:
-                node = Node2D(n_number, dof_map, self.model, *dofs)
+                node = Node2D(n_number, dof_map, self.model, *coords)
             else:
-                node = Node3D(n_number, dof_map, self.model, *dofs)
+                node = Node3D(n_number, dof_map, self.model, *coords)
 
             self.model.add_node(node)
 
@@ -491,7 +498,9 @@ class FilParser:
 
             # Append all the records
             for ix, data in enumerate(record[2:], start=1):
-                self.model.add_elem_output(n_elem, f"{var}{ix}", data, step, inc, int_point)
+                self.model.add_elem_output(
+                    n_elem, f"{var}{ix}", data, step, inc, int_point
+                )
 
         elif flag_out == 1:
             n_node = self._curr_elem_out
@@ -561,11 +570,13 @@ class FilParser:
 
         if len(record) > 2:
             for ix, r_i in enumerate(record[3:], start=1):
-                self.model.add_nodal_output(node=record[2], var=f"{var}{ix}", data=r_i,
-                                            step=step, inc=inc)
+                self.model.add_nodal_output(
+                    node=record[2], var=f"{var}{ix}", data=r_i, step=step, inc=inc
+                )
         else:
-            self.model.add_nodal_output(node=record[0], var=var, data=record[1], step=step,
-                                        inc=inc)
+            self.model.add_nodal_output(
+                node=record[0], var=var, data=record[1], step=step, inc=inc
+            )
 
         return 1
 
@@ -588,8 +599,13 @@ class FilParser:
         node = self._curr_output_node
 
         for ix, comp_i in enumerate(record[2:]):
-            self.model.add_nodal_output(node=node, var=self.CONTACT_OUT[var][ix],
-                                        data=comp_i, step=step, inc=inc)
+            self.model.add_nodal_output(
+                node=node,
+                var=self.CONTACT_OUT[var][ix],
+                data=comp_i,
+                step=step,
+                inc=inc,
+            )
 
     def _parse_contact_output_request(self, record):
         """Parse surfaces and nodes associated to contact pair.
@@ -904,7 +920,7 @@ class FilParser:
         r_type : str
 
         """
-        #tqdm.write(f"Record key {record[1]} ({r_type}) not yet implemented!")
+        # tqdm.write(f"Record key {record[1]} ({r_type}) not yet implemented!")
         print(f"Record key {record[1]} ({r_type}) not yet implemented!")
 
     def _reference_elems_in_nodes(self):

--- a/src/pybaqus/nodes.py
+++ b/src/pybaqus/nodes.py
@@ -82,12 +82,12 @@ class Node2D(Node):
     _y: float
     _rz: float
 
-    def __init__(self, num: int, dof_map, model, *dof):
+    def __init__(self, num: int, dof_map, model, *coords):
         super().__init__(num, model)
 
-        self._x = dof[dof_map[0] - 1]
-        self._y = dof[dof_map[1] - 1]
-        self._rz = dof[dof_map[5] - 1] if dof_map[5] > 0 else np.nan
+        self._x = coords[dof_map[0] - 1]
+        self._y = coords[dof_map[1] - 1]
+        self._rz = 0.0 if dof_map[5] > 0 else np.nan
         self._num = num
 
     def _get_coords(self):
@@ -116,15 +116,15 @@ class Node3D(Node):
     _ry: float
     _rz: float
 
-    def __init__(self, num, dof_map, model, *dof):
+    def __init__(self, num, dof_map, model, *coords):
         super().__init__(num, model)
 
-        self._x = dof[dof_map[0] - 1]
-        self._y = dof[dof_map[1] - 1]
-        self._z = dof[dof_map[2] - 1]
-        self._rx = dof[dof_map[3] - 1] if dof_map[3] > 0 else np.nan
-        self._ry = dof[dof_map[4] - 1] if dof_map[4] > 0 else np.nan
-        self._rz = dof[dof_map[5] - 1] if dof_map[5] > 0 else np.nan
+        self._x = coords[dof_map[0] - 1]
+        self._y = coords[dof_map[1] - 1]
+        self._z = coords[dof_map[2] - 1]
+        self._rx = 0.0 if dof_map[3] > 0 else np.nan
+        self._ry = 0.0 if dof_map[4] > 0 else np.nan
+        self._rz = 0.0 if dof_map[5] > 0 else np.nan
         self._num = num
 
     def _get_coords(self):


### PR DESCRIPTION
- fix: correctly initialize nodes coordinates:
Nodes with active rotation degrees of freedom were failing to get
initialized, because we were expecting to explicitely provide an inital
rotation. However, nodes are initalized only with coordinates (x,y) or
(x,y,z), so this was cousing an error. This fixes this issue by
initializing the rotation degrees of freedom to zero if they are active
in the model.
- Make more obvious that we are talking about node coordinates. The
  concept of dof was missleading
- Correct the type hinting